### PR TITLE
Fix SASS deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@
 - Add context menu for chat messages to allow rerolls for valid d20 rolls from the chat pane.
 - Add CHANGELOG.md.
 - Update Github Workflows.
+
+### Fixed
+
+- Fix SASS deprecation warnings.

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -11,24 +11,24 @@ import buffer from "vinyl-buffer";
 import source from "vinyl-source-stream";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
 
 import rollupStream from "@rollup/stream";
 
 import rollupConfig from "./rollup.config.mjs";
-import gulpSass from "gulp-sass";
-import dartSass from "sass";
 
 /********************/
 /*  CONFIGURATION   */
 /********************/
 
+const sass = require("gulp-sass")(require("sass"));
 const packageId = "so-inspired";
 const sourceDirectory = "./src";
 const distDirectory = "./dist";
 const stylesDirectory = `${sourceDirectory}/styles`;
 const stylesExtension = "scss";
 const sourceFileExtension = "js";
-const sass = gulpSass(dartSass);
 const staticFiles = ["module.json", "templates"];
 
 /********************/


### PR DESCRIPTION
Fixes SASS deprecation warnings

```import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.```