### PR TITLE
Tidy 5e Sheets: Integration with the upcoming new character sheet

### DIFF
--- a/src/module/so-inspired.js
+++ b/src/module/so-inspired.js
@@ -292,7 +292,7 @@ Hooks.on("changeInspirationColor", () => {
 Hooks.on("renderActorSheetV2", (_sheet, html) => {
   if (_sheet.id.split("-")[0] === "Tidy5eCharacterSheet") {
     renderTidySheet(_sheet, html);
-  } else if (_sheet.id.includes('Tidy')) {
+  } else if (_sheet.id.includes("Tidy")) {
     // New Tidy Character Sheet Inspiration Tracking is Handled via API
     return;
   } else renderNewInspoSheet(_sheet, html);
@@ -310,8 +310,8 @@ Hooks.on("renderPlayers", () => {
 Hooks.on("tidy5e-sheet.ready", (api) => {
   /** Overrides the new Tidy 5e Character Sheet's inspiration tracker */
   api.config.actorInspiration?.configureBankedInspiration({
-    /** 
-     * A callback for when an inspiration change has been requested. 
+    /**
+     * A callback for when an inspiration change has been requested.
      * The delta is -1 or 1.
      */
     change: async (app, actor, delta) => {
@@ -360,7 +360,7 @@ Hooks.on("tidy5e-sheet.ready", (api) => {
       }
     },
     /** Gets the value / max for the inspiration tracker */
-    getData: (app, actor) => {
+    getData: (app) => {
       let currentInspiration;
       const actorOwner = game.users.find(
         (u) => u.character?.uuid === app.actor.uuid

--- a/src/module/so-inspired.js
+++ b/src/module/so-inspired.js
@@ -292,6 +292,9 @@ Hooks.on("changeInspirationColor", () => {
 Hooks.on("renderActorSheetV2", (_sheet, html) => {
   if (_sheet.id.split("-")[0] === "Tidy5eCharacterSheet") {
     renderTidySheet(_sheet, html);
+  } else if (_sheet.id.includes('Tidy')) {
+    // New Tidy Character Sheet Inspiration Tracking is Handled via API
+    return;
   } else renderNewInspoSheet(_sheet, html);
 });
 
@@ -302,6 +305,87 @@ Hooks.on("updateUser", (user) => {
 Hooks.on("renderPlayers", () => {
   if (game.settings.get("so-inspired", "showInspirationOnPlayerList"))
     updatePlayerListInspo();
+});
+
+Hooks.on("tidy5e-sheet.ready", (api) => {
+  /** Overrides the new Tidy 5e Character Sheet's inspiration tracker */
+  api.config.actorInspiration?.configureBankedInspiration({
+    /** 
+     * A callback for when an inspiration change has been requested. 
+     * The delta is -1 or 1.
+     */
+    change: async (app, actor, delta) => {
+      const actorOwner = game.users.find(
+        (u) => u.character?.uuid === app.actor.uuid
+      );
+      const speaker = {
+        actor: app.actor.id,
+        alias: app.actor.name,
+        scene: game.scenes?.active.id,
+        token: app.actor.token,
+      };
+
+      if (delta < 0) {
+        await removeInspiration(actorOwner, app).then(
+          (resolveMessage) => {
+            game.soInspired.MessageHandler.toChat({
+              message: resolveMessage,
+              speaker: speaker,
+            });
+            ui.players.render();
+          },
+          (rejectMessage) => {
+            game.soInspired.MessageHandler.toChat({
+              message: rejectMessage,
+              speaker: speaker,
+            });
+          }
+        );
+      } else if (delta > 0) {
+        await addInspiration(actorOwner, app).then(
+          (resolveMessage) => {
+            game.soInspired.MessageHandler.toChat({
+              message: resolveMessage,
+              speaker: speaker,
+            });
+            ui.players.render();
+          },
+          (rejectMessage) => {
+            game.soInspired.MessageHandler.toChat({
+              message: rejectMessage,
+              speaker: speaker,
+            });
+          }
+        );
+      }
+    },
+    /** Gets the value / max for the inspiration tracker */
+    getData: (app, actor) => {
+      let currentInspiration;
+      const actorOwner = game.users.find(
+        (u) => u.character?.uuid === app.actor.uuid
+      );
+
+      if (!actorOwner) {
+        return {
+          value: 0,
+          max: 0,
+        };
+      }
+
+      currentInspiration = game.settings.get(
+        "so-inspired",
+        "useSharedInspiration"
+      )
+        ? game.settings.get("so-inspired", "sharedInspiration")
+        : actorOwner.getFlag("so-inspired", "inspirationCount");
+
+      return {
+        value: currentInspiration ?? 0,
+        max: game.settings.get("so-inspired", "maxInspiration"),
+      };
+    },
+  });
 });
 
 function renderTidySheet(app, element) {


### PR DESCRIPTION
Hello,

The Tidy 5e Sheets module has a big UI overhaul nearing its end, and in the new sheets, we have specifically provided a banked inspiration tracker that can be hooked into and overridden.

This PR demonstrates overriding the inspiration tracker and wiring "So Inspired!" logic into it.

Let me know what you think.

Here's look at it in action:

https://github.com/user-attachments/assets/9ca4274c-4aa8-46f0-bc94-339c2796d456

![image](https://github.com/user-attachments/assets/2fa0ca1f-d6bd-4812-b7a8-7948a9faea7f)

![image](https://github.com/user-attachments/assets/c4d4cfb0-706e-44fa-8a44-b3bbc82bc895)

![image](https://github.com/user-attachments/assets/5d1c9aaa-b211-4232-b7b5-ae13dd4000b8)

Hit me up on discord, and I'll give you the secret to accessing the sheets before they release to beta.